### PR TITLE
save to file (dialog)

### DIFF
--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -79,11 +79,13 @@ Menubar.File = function ( editor ) {
 
 		var output = JSON.stringify( editor.toJSON(), null, '\t' );
 
-		var blob = new Blob( [ output ], { type: 'text/plain' } );
-		var objectURL = URL.createObjectURL( blob );
-
-		window.open( objectURL, '_blank' );
-		window.focus();
+		var filename = "framejs.json"
+		var contentType = 'application/octet-stream';
+		var a = document.createElement('a');
+		var blob = new Blob([output], {'type':contentType});
+		a.href = window.URL.createObjectURL(blob);
+		a.download = filename;
+		a.click() 
 
 	}
 


### PR DESCRIPTION
Hi, exporting to a file might be more convenient (since the import-feature uses files as well).
I keep finding copy/pasting the json-code into the same file over and over again..what about you? :) 